### PR TITLE
Trim trailing whitespace that got added

### DIFF
--- a/HTMLBeautify.py
+++ b/HTMLBeautify.py
@@ -136,6 +136,10 @@ class HtmlBeautifyCommand(sublime_plugin.TextCommand):
 						tmp = ("\t" * indent_level) + item
 
 				beautified_code = beautified_code + tmp + '\n'
+				
+			# remove leading and trailing white space
+			beautified_code = beautified_code.strip()
+            	
 			# print beautified_code
 
 			# replace the code in Sublime Text


### PR DESCRIPTION
When using this plugin it added 2 newlines after closing html tag, this fix works for me
